### PR TITLE
bugfix fetchAjax

### DIFF
--- a/seajs-plugin/src/seajs-localcache.js
+++ b/seajs-plugin/src/seajs-localcache.js
@@ -198,7 +198,7 @@ define("seajs-localcache", function(require){
                         onLoad(url)
                     }else{
                         delete fetchingList[url]
-                        fetch.call(mod, requestCache)
+                        fetch.call(mod)
                     }
                 })
             }

--- a/seajs-plugin/src/seajs-localcache.js
+++ b/seajs-plugin/src/seajs-localcache.js
@@ -231,25 +231,25 @@ define("seajs-localcache", function(require){
                 comboUrl = splited.host + syntax[0] + splited.files.join(syntax[1])
             fetchAjax(comboUrl + '?v='+Math.random().toString(), function(resp){
                 if(!resp){
-                    delete fetchingList[url]
-                    fetch.call(mod, requestCache)
-                    return
+                    throw new Error('Could not load: ' + comboUrl)
                 }
                 var splitedCode = splitCombo(resp, comboUrl, splited.files)
                 if(splited.files.length == splitedCode.length){
                     //ensure they are matched with each other
                     for(var i= 0,len = splited.files.length;i<len;i++){
                         var file = splited.host + splited.files[i]
-                        localManifest[file] = remoteManifest[file]
-                        storage.set(file, splitedCode[i])
+                        if(remoteManifest[file]) {
+                            localManifest[file] = remoteManifest[file]
+                            storage.set(file, splitedCode[i])
+                        }
                         use(file, splitedCode[i])
                     }
                     storage.set('manifest', JSON.stringify(localManifest))
                     onLoad(url)
                 }else{
                     //filenames and codes not matched, fetched code is broken at somewhere.
-                    delete fetchingList[url]
-                    fetch.call(mod, requestCache)
+                    use(url, resp)
+                    onLoad(url)
                 }
             })
         }else{


### PR DESCRIPTION
1. 非combo url，请求失败，调用seajs的fetch方法则无需传requestCache。
2. 对于combo url，fetchAjax中请求失败或代码分割失败，需要调用seajs中原有fetch方法，经过测试发现都是行不通。seajs-localcache中的fetchingList和seajs中的callbacklist的作用是相同的，但是请求失败的时候，数据存储在fetchingList，callbacklist并没有存储，在调用seajs的fetch方法，就没有办法遍历combo中的其他模块。
   - 请求失败：直接抛出异常（看seajs之后能否暴露接口改进）；
   - 代码分割失败：不用再fetch代码，直接解析就可以；
